### PR TITLE
Add lazy.nvim installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@
 },
 ```
 
+Then, install the plugin with
+
+```vim
+:Lazy install
+```
+
 ### Using `vim-plug`
 
 Add the following to your `init.vim` or `init.lua`:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@
 
 ## Installation
 
+### Using lazy.nvim
+
+```lua
+{
+  "4DRIAN0RTIZ/rssfeed.nvim",
+  dependencies = {
+    "MunifTanjim/nui.nvim",
+  },
+  cmd = "RSSFeed",
+  config = function ()
+    require('rssfeed').setup({
+      open_cmd = "wslview",
+      feeds = {
+        -- Add your RSS feeds here
+        { name = "RSS Feed", url = "https://website.com/blog/rss.xml" },
+      }
+    })
+  end
+},
+```
+
 ### Using `vim-plug`
 
 Add the following to your `init.vim` or `init.lua`:


### PR DESCRIPTION
I use lazy.nvim, and I created an installation snippet for people to use to install rssfeed.nvim using it. Thought I might contribute it back upstream, given lazy.nvim's popularity.